### PR TITLE
Fix: NPE when exporting as json

### DIFF
--- a/Core/src/main/java/utils/JsonExporter.java
+++ b/Core/src/main/java/utils/JsonExporter.java
@@ -48,7 +48,7 @@ public class JsonExporter {
         result.add("binarySource", new JsonPrimitive(contract.getBinarySource()));
         result.add("binaryHash", new JsonPrimitive(contract.getContractHash()));
         result.add("isOnlyRuntime", new JsonPrimitive(contract.isOnlyRuntime()));
-        result.add("metadata", new JsonPrimitive(contract.getMetadata()));
+        result.add("metadata", new JsonPrimitive(contract.getMetadata() == null ? "" : contract.getMetadata()))
         try {
             result.add("solidityVersion", new JsonPrimitive(contract.getExactSolidityVersion()));
         } catch (SolidityVersionUnknownException e) {


### PR DESCRIPTION
There's a bug when the metadata cannot be extracted from a contract, EtherSolve will crash when run with the `-j` flag enabled.
Here's an example configuration for a crash:
```
java -jar ../ethersolve/EtherSolve_new.jar -jr 606060405236156100615760E060020A60003504630B7087BA811461006357806359221A6814610081578063597E1FB5146101165780636FD1CE48146101225780638DA5CB5B146101765780639C8300F514610188578063A035B1FE146101E5575B005B61006160005433600160A060020A0390811691161461029F57610002565B6101EE6004356003805482908110156100025750600052604080517FC2575A0E9E593C00F959F8C92F12DB2869C3395A3B0502D05E2516446F71F85B9092018054602060026001831615610100026000190190921691909104601F81018290048202850182019093528284529091908301828280156102D95780601F106102AE576101008083540402835291602001916102D9565B61025C60045460FF1681565B6040805160206004803580820135601F81018490048402850184019095528484526100619491936024939092918401919081908401838280828437509496505050505050506001543410156102E157610002565B610270600054600160A060020A031681565B6101EE60028054604080516020601F600019610100600187161502019094168590049384018190048102820181019092528281529291908301828280156102D95780601F106102AE576101008083540402835291602001916102D9565B61028D60015481565B60405180806020018281038252838181518152602001915080519060200190808383829060006004602084601F0104600F02600301F150905090810190601F16801561024E5780820380516001836020036101000A031916815260200191505B509250505060405180910390F35B604080519115158252519081900360200190F35B60408051600160A060020A03929092168252519081900360200190F35B60408051918252519081900360200190F35B6004805460FF19166001179055565B820191906000526020600020905B8154815290600101906020018083116102BC57829003601F168201915B505050505081565B60045460FF16156102F157610002565B60038054600181018083558281838015829011610321578183600052602060002091820191016103219190610390565B5050509190906000526020600020900160008390919091509080519060200190828054600181600116156101000203166002900490600052602060002090601F016020900481019282601F106103F457805160FF19168380011785555B506104249291506103DC565B50506001015B808211156103F0576000818150805460018160011615610100020316600290046000825580601F106103C2575061038A565B601F01602090049060005260206000209081019061038A91905B808211156103F057600081556001016103DC565B5090565B8280016001018555821561037E579182015B8281111561037E578251826000505591602001919060010190610406565B505060008054604051600160A060020A03919091169250349082818181858883F150505050505056
```

When run with the `-H` flag however it will generate the report file as expected: 
```
java -jar ../ethersolve/EtherSolve_new.jar -Hr 606060405236156100615760E060020A60003504630B7087BA811461006357806359221A6814610081578063597E1FB5146101165780636FD1CE48146101225780638DA5CB5B146101765780639C8300F514610188578063A035B1FE146101E5575B005B61006160005433600160A060020A0390811691161461029F57610002565B6101EE6004356003805482908110156100025750600052604080517FC2575A0E9E593C00F959F8C92F12DB2869C3395A3B0502D05E2516446F71F85B9092018054602060026001831615610100026000190190921691909104601F81018290048202850182019093528284529091908301828280156102D95780601F106102AE576101008083540402835291602001916102D9565B61025C60045460FF1681565B6040805160206004803580820135601F81018490048402850184019095528484526100619491936024939092918401919081908401838280828437509496505050505050506001543410156102E157610002565B610270600054600160A060020A031681565B6101EE60028054604080516020601F600019610100600187161502019094168590049384018190048102820181019092528281529291908301828280156102D95780601F106102AE576101008083540402835291602001916102D9565B61028D60015481565B60405180806020018281038252838181518152602001915080519060200190808383829060006004602084601F0104600F02600301F150905090810190601F16801561024E5780820380516001836020036101000A031916815260200191505B509250505060405180910390F35B604080519115158252519081900360200190F35B60408051600160A060020A03929092168252519081900360200190F35B60408051918252519081900360200190F35B6004805460FF19166001179055565B820191906000526020600020905B8154815290600101906020018083116102BC57829003601F168201915B505050505081565B60045460FF16156102F157610002565B60038054600181018083558281838015829011610321578183600052602060002091820191016103219190610390565B5050509190906000526020600020900160008390919091509080519060200190828054600181600116156101000203166002900490600052602060002090601F016020900481019282601F106103F457805160FF19168380011785555B506104249291506103DC565B50506001015B808211156103F0576000818150805460018160011615610100020316600290046000825580601F106103C2575061038A565B601F01602090049060005260206000209081019061038A91905B808211156103F057600081556001016103DC565B5090565B8280016001018555821561037E579182015B8281111561037E578251826000505591602001919060010190610406565B505060008054604051600160A060020A03919091169250349082818181858883F150505050505056
```

The cause seems to be this line: 
https://github.com/SeUniVr/EtherSolve/blob/519f3860422d53059f9181e0b7893f14eb63e05f/Core/src/main/java/utils/JsonExporter.java#L51

Which I could work around by doing a simple null check:

```java
result.add("metadata", new JsonPrimitive(contract.getMetadata() == null ? "" : contract.getMetadata()))
```

